### PR TITLE
Sprint 4 - Activar spawners por proximidad

### DIFF
--- a/Assets/Prefabs/Enemy Spawner.prefab
+++ b/Assets/Prefabs/Enemy Spawner.prefab
@@ -1,5 +1,100 @@
 %YAML 1.1
 %TAG !u! tag:unity3d.com,2011:
+--- !u!1 &5261776999366086202
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2905323692194212320}
+  - component: {fileID: 2562944611033356893}
+  - component: {fileID: 5266611118474100227}
+  - component: {fileID: 4483484478635252488}
+  m_Layer: 0
+  m_Name: Enemy trigger
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &2905323692194212320
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5261776999366086202}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 200, y: 0, z: -200}
+  m_LocalScale: {x: 400, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 6315109513449370485}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!33 &2562944611033356893
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5261776999366086202}
+  m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!23 &5266611118474100227
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5261776999366086202}
+  m_Enabled: 0
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 10303, guid: 0000000000000000f000000000000000, type: 0}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_AdditionalVertexStreams: {fileID: 0}
+--- !u!65 &4483484478635252488
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5261776999366086202}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_Enabled: 0
+  serializedVersion: 2
+  m_Size: {x: 1, y: 1, z: 1}
+  m_Center: {x: 0, y: 0, z: 0}
 --- !u!1 &6315109513449370484
 GameObject:
   m_ObjectHideFlags: 0
@@ -27,7 +122,8 @@ Transform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 5, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
-  m_Children: []
+  m_Children:
+  - {fileID: 2905323692194212320}
   m_Father: {fileID: 0}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -44,5 +140,9 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   enemy: {fileID: 7870836692146159795, guid: e836bc10b8daa4446866557c07e80f56, type: 3}
+  startDelayTime: 1
   spawnDelayTime: 5
   maxEnemies: 10
+  spawnerTrigger: {fileID: 2905323692194212320}
+  waypoints: []
+  visualizeWaypoints: 0

--- a/Assets/Scripts/Enemy/EnemySpawner.cs
+++ b/Assets/Scripts/Enemy/EnemySpawner.cs
@@ -10,24 +10,36 @@ public class EnemySpawner : MonoBehaviour {
     [SerializeField] private float startDelayTime = 1.0f;
     [SerializeField] private float spawnDelayTime = 5.0f;
     [SerializeField] private int maxEnemies = 5;
-
+    [SerializeField] private Transform spawnerTrigger;
+    
     public List<GameObject> waypoints;
     [SerializeField] private bool visualizeWaypoints;
+
+    private bool _isSpawning = false;
+    private Camera _camera;
     
     private void Start() {
-        StartCoroutine(SpawnEnemy(spawnDelayTime));
+        _camera = FindObjectOfType<Camera>();
     }
 
-    private IEnumerator SpawnEnemy(float waitTime) {
-        int enemyCount = 0;
-        yield return new WaitForSeconds(startDelayTime);
-        while (enemyCount < maxEnemies) {
-            GameObject newEnemy = Instantiate(enemy, transform.position, transform.rotation);
-            newEnemy.GetComponent<EnemyMovement>().path = waypoints;
-            enemyCount++;
-            yield return new WaitForSeconds(waitTime);    
+    private void Update() {
+        if (!_isSpawning && _camera.transform.position.z >= spawnerTrigger.position.z) {
+            _isSpawning = true;
+            StartCoroutine(SpawnEnemy(spawnDelayTime));
         }
+    }
 
+    public IEnumerator SpawnEnemy(float waitTime) {
+        if (_isSpawning) {
+            int enemyCount = 0;
+            yield return new WaitForSeconds(startDelayTime);
+            while (enemyCount < maxEnemies) {
+                GameObject newEnemy = Instantiate(enemy, transform.position, transform.rotation);
+                newEnemy.GetComponent<EnemyMovement>().path = waypoints;
+                enemyCount++;
+                yield return new WaitForSeconds(waitTime);    
+            }            
+        }
     }
 
     public void CreateNewWaypoint() {


### PR DESCRIPTION
**Yo como**: Usuario
**Quiero**: Que los enemigos se generen cuando el jugador está cerca
**Para**: Que el jugador vaya teniendo objetivos a los que disparar
## **Criterios de Aceptación:**
---
-**Dado:** Que el jugador entre al juego
-**Cuando:** El usuario entra a la aplicación
-**Entonces:** Los "spawners" de enemigos empiezan apagados, osea, no invocan enemigos.

---
-**Dado:** Que el jugador esta cerca de un enemigo
-**Cuando:** La cámara de desplaza cerca de el rango de activación de un "spawner" de enemigos
-**Entonces:** Los spawners que se encuentran en el rango de activación de la cámara empiezan a generar enemigos.

### Esfuerzo: 8