### PR TITLE
Sprint 5 - El cambio de power up no es inmediato

### DIFF
--- a/Assets/Scripts/Player/PlayerShot.cs
+++ b/Assets/Scripts/Player/PlayerShot.cs
@@ -8,12 +8,14 @@ public class PlayerShot : MonoBehaviour {
     [SerializeField] private float _durationShot = 5.0f;
     [SerializeField] ParticleSystem[] particleSystems;
     private AudioSource _audioSource;
+    private bool _isShooting = false;
   
     void Start() {                   
             _audioSource = GetComponent<AudioSource>();        
     }
 
     public void ProcessShoot(bool isShooting) {
+        _isShooting = isShooting;
         foreach (ParticleSystem gun in particleSystems) {
             if (isShooting) {
                 gun.Play();
@@ -33,7 +35,8 @@ public class PlayerShot : MonoBehaviour {
         if(other.gameObject.GetComponent<PowerUp>()) {
             StartCoroutine(shotDuration());
             particleSystems[2].gameObject.SetActive(true);
-            particleSystems[3].gameObject.SetActive(true);                        
+            particleSystems[3].gameObject.SetActive(true);
+            ProcessShoot(_isShooting);                        
             Destroy(other.gameObject);
         }
     }


### PR DESCRIPTION
**Yo como**: Usuario
**Quiero**: Que la mejora a los cañones del power up se aplique a mi nave de manera instantánea.
**Para**:  No tener la necesidad de volver a apretar el botón de disparo para que dicha mejora se aplique a la nave del jugador.
## **Criterios de Aceptación:**
---
**Dado:** Que el jugador recolecta un Power Up de disparo
**Cuando:** La nave del jugador colisiona contra un objeto de tipo Power Up.
**Entonces:**  Los disparos del jugador harán uso del Power up de manera inmediata.

### Esfuerzo: 5